### PR TITLE
Fix uvicorn startup by adding app compatibility package

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,9 @@
+"""Compatibility package exposing the FastAPI application.
+
+This shim allows running ``uvicorn app.main:app`` without requiring
+``src`` to be on the Python import path.  It simply re-exports the
+application object from the actual implementation under ``src/app``.
+"""
+from src.app.main import app
+
+__all__ = ["app"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for :mod:`src.app.main`.
+
+Uvicorn expects to import ``app.main:app`` based on the project README
+and container configuration.  When the source layout keeps the real
+application inside ``src/app``, importing ``app`` would normally fail.
+This module re-exports the FastAPI ``app`` instance from its actual
+location so that existing commands continue to work.
+"""
+from src.app.main import app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add a top-level `app` compatibility package so `uvicorn app.main:app` can import the FastAPI instance

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e3b7a833fc8327865d0fac6e624703