### PR TITLE
Add vector store storage and query pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@
    # ok
    ```
 
+4. Выполните тестовый запрос к векторному поиску (после наполнения БД чанками):
+   ```bash
+   curl -X POST "http://localhost:8000/query" \
+        -H "Content-Type: application/json" \
+        -d '{"text": "пример запроса", "k": 5}'
+   ```
+
 ## Разработка без Docker
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ PyPDF2==3.0.1
 python-docx==0.8.11
 langdetect==1.0.9
 fpdf2==2.7.8
+chromadb==0.4.24
+sentence-transformers==2.2.2
+torch==2.2.2

--- a/src/app/embeddings.py
+++ b/src/app/embeddings.py
@@ -1,0 +1,89 @@
+"""Utility helpers for working with embedding models."""
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from sentence_transformers import SentenceTransformer
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_MODEL_NAME = "BAAI/bge-m3"
+FALLBACK_MODEL_NAME = "sentence-transformers/stsb-xlm-r-multilingual"
+
+
+def _models_root() -> Path:
+    return Path(os.getenv("MODELS_DIR", "models"))
+
+
+def _find_local_model_path(model_name: str) -> Path | None:
+    """Search for a locally downloaded embedding model."""
+
+    candidates: Iterable[Path] = (
+        Path(model_name),
+        _models_root() / model_name,
+        _models_root() / model_name.split("/")[-1],
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_model_name() -> str:
+    """Choose the embedding model with fallback logic."""
+
+    env_model = os.getenv("EMBEDDING_MODEL")
+    if env_model:
+        LOGGER.info("Using embedding model from environment: %s", env_model)
+        return env_model
+
+    local_bge = _find_local_model_path(DEFAULT_MODEL_NAME)
+    if local_bge:
+        LOGGER.info("Found local BGE-M3 model at %s", local_bge)
+        return str(local_bge)
+
+    LOGGER.info("Falling back to default multilingual STS-B model")
+    return FALLBACK_MODEL_NAME
+
+
+class EmbeddingModel:
+    """Wrapper around a sentence-transformer embedding model."""
+
+    def __init__(self, model_name: str | None = None, batch_size: int = 32, normalize: bool = True) -> None:
+        self.model_name = model_name or _resolve_model_name()
+        self.batch_size = batch_size
+        self.normalize = normalize
+        self._model = self._load_model(self.model_name)
+
+    @staticmethod
+    def _load_model(model_name: str) -> SentenceTransformer:
+        LOGGER.info("Loading embedding model: %s", model_name)
+        return SentenceTransformer(model_name)
+
+    def embed_texts(self, texts: Sequence[str]) -> List[List[float]]:
+        if not texts:
+            return []
+        embeddings = self._model.encode(
+            list(texts),
+            batch_size=self.batch_size,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            normalize_embeddings=self.normalize,
+        )
+        return embeddings.tolist()
+
+    @property
+    def dimension(self) -> int:
+        return int(self._model.get_sentence_embedding_dimension())
+
+
+@lru_cache()
+def get_embedding_model() -> EmbeddingModel:
+    """Return a cached embedding model instance."""
+
+    return EmbeddingModel()
+

--- a/src/app/ingest/__init__.py
+++ b/src/app/ingest/__init__.py
@@ -1,10 +1,12 @@
 """Document ingestion pipeline for Legal Bot."""
+from .embedding_pipeline import ChunkEmbeddingPipeline
 from .pipeline import IngestPipeline
 from .models import DocumentChunk, ChunkMetadata, PageContent
 from .format_detection import DocumentFormat, DocumentFormatDetector
 
 __all__ = [
     "IngestPipeline",
+    "ChunkEmbeddingPipeline",
     "DocumentChunk",
     "ChunkMetadata",
     "PageContent",

--- a/src/app/ingest/embedding_pipeline.py
+++ b/src/app/ingest/embedding_pipeline.py
@@ -1,0 +1,20 @@
+"""Pipeline for computing embeddings and storing them in the vector DB."""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from app.ingest.models import DocumentChunk
+from app.vectorstore import ChunkVectorStore
+
+
+class ChunkEmbeddingPipeline:
+    """Takes prepared document chunks and persists them into Chroma."""
+
+    def __init__(self, vector_store: Optional[ChunkVectorStore] = None) -> None:
+        self.vector_store = vector_store or ChunkVectorStore()
+
+    def run(self, chunks: Sequence[DocumentChunk]) -> List[str]:
+        """Compute embeddings for chunks and upsert them into the vector store."""
+
+        return self.vector_store.upsert_chunks(list(chunks))
+

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+
+from app.vectorstore import ChunkSearchResult, ChunkVectorStore, get_vector_store
 
 app = FastAPI(title="Legal Bot API")
 
@@ -8,3 +11,39 @@ app = FastAPI(title="Legal Bot API")
 def read_root() -> str:
     """Healthcheck endpoint for the service."""
     return "ok"
+
+
+class QueryRequest(BaseModel):
+    text: str = Field(..., description="Query text to search for similar chunks.")
+    k: int = Field(5, ge=1, le=50, description="Number of results to return.")
+
+
+class QueryResponseItem(BaseModel):
+    id: str
+    distance: float
+    content: str
+    metadata: dict
+
+
+class QueryResponse(BaseModel):
+    results: list[QueryResponseItem]
+
+
+def _serialize_result(result: ChunkSearchResult) -> QueryResponseItem:
+    return QueryResponseItem(
+        id=result.id,
+        distance=result.distance,
+        content=result.content,
+        metadata=result.metadata,
+    )
+
+
+@app.post("/query", response_model=QueryResponse)
+def query_vector_store(
+    request: QueryRequest,
+    store: ChunkVectorStore = Depends(get_vector_store),
+) -> QueryResponse:
+    """Query the vector store by plain text and return similar chunks."""
+
+    results = store.query_by_text(request.text, k=request.k)
+    return QueryResponse(results=[_serialize_result(item) for item in results])

--- a/src/app/vectorstore.py
+++ b/src/app/vectorstore.py
@@ -1,0 +1,167 @@
+"""Vector store implementation backed by ChromaDB."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import shutil
+import uuid
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import chromadb
+from chromadb.api import ClientAPI
+from chromadb.api.models.Collection import Collection
+from chromadb.config import Settings
+from chromadb.errors import NotEnoughElementsException
+
+from app.embeddings import EmbeddingModel, get_embedding_model
+from app.ingest.models import DocumentChunk
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ChunkSearchResult:
+    """Structured response returned from similarity search queries."""
+
+    id: str
+    content: str
+    distance: float
+    metadata: Dict[str, Any]
+
+
+class ChunkVectorStore:
+    """Wrapper around Chroma persistent collections for chunk storage."""
+
+    def __init__(
+        self,
+        *,
+        persist_dir: str | Path | None = None,
+        collection_name: str = "legal_chunks",
+        distance_metric: str = "cosine",
+        embedding_model: Optional[EmbeddingModel] = None,
+    ) -> None:
+        self.persist_dir = Path(
+            persist_dir or os.getenv("CHROMA_PERSIST_DIR", Path("chroma_db"))
+        ).resolve()
+        self.persist_dir.mkdir(parents=True, exist_ok=True)
+        self.collection_name = collection_name
+        self.distance_metric = distance_metric
+        self.embedding_model = embedding_model or get_embedding_model()
+        self._client = self._create_client(self.persist_dir)
+        self._collection = self._get_or_create_collection()
+
+    @staticmethod
+    def _create_client(persist_dir: Path) -> ClientAPI:
+        settings = Settings(
+            chroma_db_impl="duckdb+parquet",
+            anonymized_telemetry=False,
+        )
+        return chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+
+    def _get_or_create_collection(self) -> Collection:
+        LOGGER.info("Opening Chroma collection '%s' in %s", self.collection_name, self.persist_dir)
+        return self._client.get_or_create_collection(
+            name=self.collection_name,
+            metadata={"hnsw:space": self.distance_metric},
+        )
+
+    @property
+    def collection(self) -> Collection:
+        return self._collection
+
+    def _generate_chunk_id(self, chunk: DocumentChunk) -> str:
+        meta = chunk.metadata
+        hash_source = f"{meta.file_id}:{meta.chunk_index}:{meta.char_start}:{meta.char_end}"
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, hash_source))
+
+    def upsert_chunks(self, chunks: Sequence[DocumentChunk]) -> List[str]:
+        if not chunks:
+            return []
+
+        documents = [chunk.content for chunk in chunks]
+        metadatas = [self._prepare_metadata(chunk) for chunk in chunks]
+        ids = [self._generate_chunk_id(chunk) for chunk in chunks]
+        embeddings = self.embedding_model.embed_texts(documents)
+
+        LOGGER.info("Upserting %s chunks into vector store", len(chunks))
+        self.collection.upsert(
+            ids=ids,
+            documents=documents,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+        self._client.persist()
+        return ids
+
+    def _prepare_metadata(self, chunk: DocumentChunk) -> Dict[str, Any]:
+        metadata = asdict(chunk.metadata)
+        metadata["content_length"] = len(chunk.content)
+        return metadata
+
+    def query_by_text(self, text: str, k: int = 5) -> List[ChunkSearchResult]:
+        if not text.strip():
+            return []
+        if k <= 0:
+            return []
+
+        if self.collection.count() == 0:
+            return []
+
+        query_embeddings = self.embedding_model.embed_texts([text])
+        if not query_embeddings:
+            return []
+        query_embedding = query_embeddings[0]
+        try:
+            result = self.collection.query(
+                query_embeddings=[query_embedding],
+                n_results=k,
+                include=["metadatas", "documents", "distances", "ids"],
+            )
+        except NotEnoughElementsException:
+            result = self.collection.query(
+                query_embeddings=[query_embedding],
+                n_results=1,
+                include=["metadatas", "documents", "distances", "ids"],
+            )
+
+        ids = result.get("ids", [[]])[0]
+        documents = result.get("documents", [[]])[0]
+        metadatas = result.get("metadatas", [[]])[0]
+        distances = result.get("distances", [[]])[0]
+
+        search_results: List[ChunkSearchResult] = []
+        for chunk_id, document, metadata, distance in zip(ids, documents, metadatas, distances):
+            search_results.append(
+                ChunkSearchResult(id=chunk_id, content=document, distance=float(distance), metadata=metadata or {})
+            )
+        return search_results
+
+    def create_snapshot(self, snapshot_dir: Path | None = None) -> Path:
+        if snapshot_dir is None:
+            snapshot_dir = self.persist_dir.parent / "snapshots"
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        snapshot_path = snapshot_dir / f"{self.collection_name}-{timestamp}"
+        LOGGER.info("Creating vector store snapshot at %s", snapshot_path)
+        if not self.persist_dir.exists():
+            raise FileNotFoundError(f"Persist directory {self.persist_dir} does not exist")
+        self._client.persist()
+        shutil.copytree(self.persist_dir, snapshot_path)
+        return snapshot_path
+@lru_cache()
+def get_vector_store() -> ChunkVectorStore:
+    """Return a lazily initialised vector store instance."""
+
+    return ChunkVectorStore()
+
+
+def reset_vector_store_cache() -> None:
+    """Clear the cached vector store (primarily for testing)."""
+
+    get_vector_store.cache_clear()  # type: ignore[attr-defined]
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.vectorstore import ChunkSearchResult, get_vector_store
 
 
 def test_read_root_returns_ok() -> None:
@@ -8,3 +9,18 @@ def test_read_root_returns_ok() -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.text == "ok"
+
+
+def test_query_endpoint_returns_results() -> None:
+    class DummyStore:
+        def query_by_text(self, text: str, k: int = 5):
+            return [ChunkSearchResult(id="chunk-1", content="answer", distance=0.05, metadata={"chunk_index": 1})]
+
+    app.dependency_overrides[get_vector_store] = lambda: DummyStore()
+    client = TestClient(app)
+    response = client.post("/query", json={"text": "question", "k": 1})
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["results"][0]["id"] == "chunk-1"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+import pytest
+
+from app.ingest.embedding_pipeline import ChunkEmbeddingPipeline
+from app.ingest.models import ChunkMetadata, DocumentChunk
+from app.vectorstore import ChunkSearchResult, ChunkVectorStore
+
+
+@dataclass
+class _DummyEmbeddingModel:
+    """Simple deterministic embedding model used for tests."""
+
+    def embed_texts(self, texts: Sequence[str]) -> List[List[float]]:  # pragma: no cover - trivial
+        return [[float(len(text))] for text in texts]
+
+
+@pytest.fixture()
+def vector_store(tmp_path: Path) -> ChunkVectorStore:
+    return ChunkVectorStore(persist_dir=tmp_path / "chroma", distance_metric="l2", embedding_model=_DummyEmbeddingModel())
+
+
+def _make_chunk(index: int, content: str = "Example text", file_id: str = "file-1") -> DocumentChunk:
+    metadata = ChunkMetadata(
+        file_id=file_id,
+        file_name="document.txt",
+        page=1,
+        chunk_index=index,
+        char_start=index * 10,
+        char_end=index * 10 + len(content),
+        language="ru",
+    )
+    return DocumentChunk(content=content, metadata=metadata)
+
+
+def test_upsert_and_query_returns_results(vector_store: ChunkVectorStore) -> None:
+    chunks = [
+        _make_chunk(0, content="short"),
+        _make_chunk(1, content="a little bit longer"),
+        _make_chunk(2, content="the longest chunk text so far"),
+    ]
+
+    pipeline = ChunkEmbeddingPipeline(vector_store=vector_store)
+    pipeline.run(chunks)
+
+    results = vector_store.query_by_text("long chunk", k=2)
+    assert len(results) == 2
+    # Shortest distance should belong to the longest chunk because of our dummy embeddings
+    assert results[0].metadata["chunk_index"] == 2
+    assert isinstance(results[0], ChunkSearchResult)
+
+
+def test_create_snapshot_creates_directory(vector_store: ChunkVectorStore, tmp_path: Path) -> None:
+    vector_store.upsert_chunks([_make_chunk(0)])
+
+    snapshot_root = tmp_path / "snapshots"
+    snapshot_path = vector_store.create_snapshot(snapshot_root)
+
+    assert snapshot_path.exists()
+    assert snapshot_path.parent == snapshot_root


### PR DESCRIPTION
## Summary
- add embedding utilities and a persistent Chroma-backed vector store with snapshot support
- wire document chunk embedding pipeline and expose a `/query` FastAPI endpoint
- cover the new pipeline and API behaviour with unit tests

## Testing
- pytest *(fails: required dependencies could not be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b987b3288327869618cdc8e77468